### PR TITLE
Update base-contet.component.html

### DIFF
--- a/core/templates/base-components/base-content.component.html
+++ b/core/templates/base-components/base-content.component.html
@@ -5,9 +5,6 @@
       <ng-content select="page-footer"></ng-content>
     </span>
   </ng-container>
-  <ng-container *ngIf="ref.childNodes.length == 0">
-    <oppia-footer></oppia-footer>
-  </ng-container>
 </ng-template>
 
 <main>


### PR DESCRIPTION
To fix this, we can remove the code that renders the otter image on top of the response. You can find this code in the ng-template #footerTpl section of the code you shared. Specifically, you can remove the following line: <oppia-footer></oppia-footer>

## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of oppia#[15152].
2. This PR does the following: [ The problem of The image of otter is shown unexpectedly while submitting the response. In fast network, it looks fine but in a slow network it's easily observable. The image should only visible next to the response and not on top. how to slove this tell me code wise is solved]

## Essential Checklist

- [1 ] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [1 ] The linter/Karma presubmit checks have passed locally on your machine.
- [ 1] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
  - This lets reviewers restart your CircleCI tests for you.
- [ ] The PR is made from a branch that's **not** called "develop".

